### PR TITLE
fix: remove DIDDoc context validation and tests

### DIFF
--- a/indy_node/server/request_handlers/domain_req_handlers/nym_handler.py
+++ b/indy_node/server/request_handlers/domain_req_handlers/nym_handler.py
@@ -197,16 +197,6 @@ class NymHandler(PNymHandler):
         if diddoc.get("id", None):
             raise InvalidDIDDocException
 
-        context = diddoc.get("@context", None)
-        if context:
-            # Must be string or array and contain DID_CONTEXT
-            if not isinstance(context, (list, str)):
-                raise InvalidDIDDocException
-            if isinstance(context, str) and not context == DID_CONTEXT:
-                raise InvalidDIDDocException
-            elif isinstance(context, list) and DID_CONTEXT not in context:
-                raise InvalidDIDDocException
-
         # No element in diddoc is allowed to have same id as verkey in base diddoc
         # Alernative would be to merge with base did doc and perform generic did doc validation,
         # e.g. using pyDID

--- a/indy_node/test/nym_txn/test_nym_did_indy.py
+++ b/indy_node/test/nym_txn/test_nym_did_indy.py
@@ -219,26 +219,6 @@ def test_add_arbitrary_property(
     assert replies[0][1]["result"]["txn"]["data"]["someProp"] == "someValue"
 
 
-def test_add_diddoc_content_did_context_missing_fails(
-    looper, sdk_pool_handle, sdk_wallet_endorser, prepare_endorser
-):
-    _, did = sdk_wallet_endorser
-    diddoc_content_without_did_context = copy.deepcopy(diddoc_content)
-    diddoc_content_without_did_context["@context"] = [
-        "https://identity.foundation/didcomm-messaging/service-endpoint/v1"
-    ]
-    nym_request = build_nym_request(
-        did, did, None, diddoc_content_without_did_context, None
-    )
-    request_couple = sdk_sign_and_send_prepared_request(
-        looper, sdk_wallet_endorser, sdk_pool_handle, nym_request
-    )
-    with pytest.raises(RequestNackedException) as e:
-        sdk_get_and_check_replies(looper, [request_couple])
-    e.match("InvalidClientRequest")
-    e.match("Invalid DIDDOC_Content")
-
-
 def test_add_didoc_with_id_fails(
     looper, sdk_pool_handle, sdk_wallet_endorser, prepare_endorser
 ):

--- a/indy_node/test/request_handlers/test_nym_handler.py
+++ b/indy_node/test/request_handlers/test_nym_handler.py
@@ -142,23 +142,6 @@ def test_nym_static_validation_fails_diddoc_content_with_id(
         nym_handler.static_validation(nym_request)
 
 
-def test_nym_static_validation_fails_diddoc_content_with_context_is_not_did_context(
-    nym_request_factory, doc, nym_handler: NymHandler
-):
-    doc["@context"] = randomString()
-    nym_request = nym_request_factory(doc)
-    with pytest.raises(InvalidClientRequest):
-        nym_handler.static_validation(nym_request)
-
-
-def test_nym_static_validation_diddoc_content_with_did_context(
-    nym_request_factory, doc, nym_handler: NymHandler
-):
-    doc["@context"] = "https://www.w3.org/ns/did/v1"
-    nym_request = nym_request_factory(doc)
-    nym_handler.static_validation(nym_request)
-
-
 def test_nym_static_validation_diddoc_content_without_context(
     nym_request_factory, doc, nym_handler: NymHandler
 ):


### PR DESCRIPTION
This PR removes the validation of DIDDoc `@context` in the `nym_handler` and associated tests. These changes have been made to align with the did:indy specification per [indy-did-method PR #58](https://github.com/hyperledger/indy-did-method/pull/58)

Signed-off-by: Char Howland <char@indicio.tech>