### PR TITLE
Test/get nym handler

### DIFF
--- a/indy_node/server/request_handlers/read_req_handlers/get_nym_handler.py
+++ b/indy_node/server/request_handlers/read_req_handlers/get_nym_handler.py
@@ -8,6 +8,7 @@ from plenum.common.constants import TARGET_NYM, TXN_TIME, DOMAIN_LEDGER_ID, TXN_
 from plenum.common.request import Request
 from plenum.common.types import f
 from plenum.common.txn_util import get_txn_time
+from plenum.common.exceptions import InvalidClientRequest
 from plenum.server.database_manager import DatabaseManager
 from plenum.server.request_handlers.handler_interfaces.read_request_handler import (
     ReadRequestHandler,
@@ -29,6 +30,12 @@ class GetNymHandler(ReadRequestHandler):
         # See https://hyperledger.github.io/indy-did-method/#did-versions
         timestamp = request.operation.get(TIMESTAMP, None)
         read_seq_no = request.operation.get("seqNo", None)
+        if timestamp and read_seq_no:
+            raise InvalidClientRequest(
+                request.identifier,
+                request.reqId,
+                "Cannot resolve nym with both seqNo and timestamp present.",
+            )
         if read_seq_no:
             # Move to this to init?
             db = self.database_manager.get_database(DOMAIN_LEDGER_ID)

--- a/indy_node/server/request_handlers/read_req_handlers/get_nym_handler.py
+++ b/indy_node/server/request_handlers/read_req_handlers/get_nym_handler.py
@@ -34,7 +34,7 @@ class GetNymHandler(ReadRequestHandler):
             raise InvalidClientRequest(
                 request.identifier,
                 request.reqId,
-                "Cannot resolve nym with both seqNo and timestamp present.",
+                "Cannot resolve nym with both seqNo and timestamp present",
             )
         if read_seq_no:
             # Move to this to init?

--- a/indy_node/test/conftest.py
+++ b/indy_node/test/conftest.py
@@ -59,6 +59,7 @@ from indy_common.test.conftest import general_conf_tdir, tconf as _tconf, poolTx
     domainTxnOrderedFields, looper, setTestLogLevel, node_config_helper_class, config_helper_class
 
 from indy_node.test.helper import TestNode, TestNodeBootstrap
+from indy_node.test.mock import build_nym_request
 
 from indy_node.server.upgrader import Upgrader
 from indy_node.utils.node_control_utils import NodeControlUtil
@@ -168,6 +169,20 @@ def sdk_node_theta_added(looper,
         looper.run(checkNodesConnected(txnPoolNodeSet))
     sdk_pool_refresh(looper, sdk_pool_handle)
     return new_steward_wallet, new_node
+
+
+@pytest.fixture(scope="module")
+def sdk_wallet_endorser_factory(looper, sdk_pool_handle, sdk_wallet_trustee):
+    def _sdk_wallet_endorser_factory(diddoc_content):
+        wh, did = sdk_add_new_nym(looper, sdk_pool_handle, sdk_wallet_trustee,
+            alias='TA-1', role='ENDORSER')
+        nym_request = build_nym_request(did, did, None, diddoc_content, None)
+        request_couple = sdk_sign_and_send_prepared_request(
+            looper, (wh, did), sdk_pool_handle, nym_request
+        )
+        sdk_get_and_check_replies(looper, [request_couple])
+        return wh, did
+    return _sdk_wallet_endorser_factory
 
 
 @pytest.fixture(scope="module")

--- a/indy_node/test/nym_txn/test_nym_did_indy.py
+++ b/indy_node/test/nym_txn/test_nym_did_indy.py
@@ -1,12 +1,11 @@
 import copy
 import json
-import time
 from random import randint
 
 import pytest
 from indy.did import create_and_store_my_did
 from indy_common.constants import ENDORSER, NYM
-from indy_node.test.mock import build_get_nym_request, build_nym_request
+from indy_node.test.mock import build_nym_request
 from plenum.common.exceptions import RequestNackedException
 from plenum.common.util import randomString
 from plenum.test.helper import sdk_get_and_check_replies
@@ -59,141 +58,6 @@ def add_diddoc_content(looper, sdk_pool_handle, sdk_wallet_endorser, prepare_end
 
 def test_diddoc_content_added(add_diddoc_content):
     pass
-
-
-def test_get_nym_data_with_diddoc_content(
-    looper, sdk_pool_handle, sdk_wallet_endorser, add_diddoc_content
-):
-    _, did = sdk_wallet_endorser
-    get_nym_request = build_get_nym_request(did, did)
-    request_couple = sdk_sign_and_send_prepared_request(
-        looper, sdk_wallet_endorser, sdk_pool_handle, get_nym_request
-    )
-    replies = sdk_get_and_check_replies(looper, [request_couple])
-
-    assert (
-        json.loads(replies[0][1]["result"]["data"])["diddocContent"] == diddoc_content_json
-    )
-
-
-def test_get_previous_nym_data_by_timestamp(
-    looper, sdk_pool_handle, sdk_wallet_endorser, add_diddoc_content
-):
-    _, did = sdk_wallet_endorser
-
-    # Get current nym data
-    get_nym_request = build_get_nym_request(did, did)
-    request_couple = sdk_sign_and_send_prepared_request(
-        looper, sdk_wallet_endorser, sdk_pool_handle, get_nym_request
-    )
-    replies = sdk_get_and_check_replies(looper, [request_couple])
-
-    # Get timestamp from data
-    timestamp = replies[0][1]["result"]["txnTime"]
-
-    # Write new nym data
-    new_diddoc_content = copy.deepcopy(diddoc_content)
-    new_diddoc_content["serviceEndpoint"][0][
-        "serviceEndpoint"
-    ] = "https://new.example.com"
-    new_diddoc_content = json.dumps(new_diddoc_content)
-
-    time.sleep(3)
-
-    nym_request = build_nym_request(
-        identifier=did, dest=did, diddoc_content=new_diddoc_content
-    )
-    request_couple = sdk_sign_and_send_prepared_request(
-        looper, sdk_wallet_endorser, sdk_pool_handle, nym_request
-    )
-    sdk_get_and_check_replies(looper, [request_couple])
-
-    get_nym_request = build_get_nym_request(did, did)
-    request_couple = sdk_sign_and_send_prepared_request(
-        looper, sdk_wallet_endorser, sdk_pool_handle, get_nym_request
-    )
-    replies = sdk_get_and_check_replies(looper, [request_couple])
-
-    assert (
-        json.loads(replies[0][1]["result"]["data"])["diddocContent"] == new_diddoc_content
-    )
-
-    update_ts = replies[0][1]["result"]["txnTime"]
-
-    # Get previous nym data by exact timestamp
-    get_nym_request = build_get_nym_request(did, did, timestamp)
-    request_couple = sdk_sign_and_send_prepared_request(
-        looper, sdk_wallet_endorser, sdk_pool_handle, get_nym_request
-    )
-    replies = sdk_get_and_check_replies(looper, [request_couple])
-
-    assert (
-        json.loads(replies[0][1]["result"]["data"])["diddocContent"] == diddoc_content_json
-    )
-
-    # Get previous nym data by timestamp but not exact
-    ts = randint(timestamp + 1, update_ts - 1)
-    get_nym_request = build_get_nym_request(did, did, ts)
-    request_couple = sdk_sign_and_send_prepared_request(
-        looper, sdk_wallet_endorser, sdk_pool_handle, get_nym_request
-    )
-    replies = sdk_get_and_check_replies(looper, [request_couple])
-
-    assert (
-        json.loads(replies[0][1]["result"]["data"])["diddocContent"] == diddoc_content_json
-    )
-
-
-def test_get_previous_nym_data_by_seq_no(
-    looper, sdk_pool_handle, sdk_wallet_endorser, add_diddoc_content
-):
-    _, did = sdk_wallet_endorser
-
-    # Get current nym data
-    get_nym_request = build_get_nym_request(did, did)
-    request_couple = sdk_sign_and_send_prepared_request(
-        looper, sdk_wallet_endorser, sdk_pool_handle, get_nym_request
-    )
-    replies = sdk_get_and_check_replies(looper, [request_couple])
-
-    # Get seq_no from data
-    seq_no = replies[0][1]["result"]["seqNo"]
-
-    # Write new nym data
-    new_diddoc_content = copy.deepcopy(diddoc_content)
-    new_diddoc_content["serviceEndpoint"][0][
-        "serviceEndpoint"
-    ] = "https://new.example.com"
-    new_diddoc_content = json.dumps(new_diddoc_content)
-
-    time.sleep(3)
-
-    nym_request = build_nym_request(did, did, None, new_diddoc_content, None)
-    request_couple = sdk_sign_and_send_prepared_request(
-        looper, sdk_wallet_endorser, sdk_pool_handle, nym_request
-    )
-    sdk_get_and_check_replies(looper, [request_couple])
-
-    get_nym_request = build_get_nym_request(did, did)
-    request_couple = sdk_sign_and_send_prepared_request(
-        looper, sdk_wallet_endorser, sdk_pool_handle, get_nym_request
-    )
-    replies = sdk_get_and_check_replies(looper, [request_couple])
-
-    assert (
-        json.loads(replies[0][1]["result"]["data"])["diddocContent"] == new_diddoc_content
-    )
-
-    # Get previous nym data by seq_no
-    get_nym_request = build_get_nym_request(did, did, seq_no=seq_no)
-    request_couple = sdk_sign_and_send_prepared_request(
-        looper, sdk_wallet_endorser, sdk_pool_handle, get_nym_request
-    )
-    replies = sdk_get_and_check_replies(looper, [request_couple])
-
-    assert (
-        json.loads(replies[0][1]["result"]["data"])["diddocContent"] == diddoc_content_json
-    )
 
 
 # Schema of NYM Tx in plenum is not enforced! Arbitrary properties can be injected, but won't be included in state

--- a/indy_node/test/request_handlers/test_get_nym_handler.py
+++ b/indy_node/test/request_handlers/test_get_nym_handler.py
@@ -75,8 +75,9 @@ def test_get_nym_data_with_diddoc_content_without_seqNo_or_timestamp(
 
 
 def test_get_previous_nym_data_by_timestamp(
-    looper, sdk_pool_handle, sdk_wallet_endorser, add_diddoc_content
+    looper, sdk_pool_handle, sdk_wallet_endorser_factory, add_diddoc_content
 ):
+    sdk_wallet_endorser = sdk_wallet_endorser_factory(diddoc_content)
     _, did = sdk_wallet_endorser
 
     # Get current nym data
@@ -143,8 +144,9 @@ def test_get_previous_nym_data_by_timestamp(
 
 
 def test_get_previous_nym_data_by_seq_no(
-    looper, sdk_pool_handle, sdk_wallet_endorser, add_diddoc_content
+    looper, sdk_pool_handle, sdk_wallet_endorser_factory, add_diddoc_content
 ):
+    sdk_wallet_endorser = sdk_wallet_endorser_factory(diddoc_content)
     _, did = sdk_wallet_endorser
 
     # Get current nym data

--- a/indy_node/test/request_handlers/test_get_nym_handler.py
+++ b/indy_node/test/request_handlers/test_get_nym_handler.py
@@ -1,0 +1,244 @@
+import copy
+import json
+import time
+from random import randint
+
+import pytest
+from indy.did import create_and_store_my_did
+from indy_common.constants import ENDORSER, NYM
+from plenum.common.exceptions import InvalidClientRequest
+from indy_node.test.mock import build_get_nym_request, build_nym_request
+from plenum.common.util import randomString
+from plenum.test.helper import sdk_get_and_check_replies
+from plenum.test.pool_transactions.helper import sdk_sign_and_send_prepared_request
+
+diddoc_content = {
+    "@context": [
+        "https://www.w3.org/ns/did/v1",
+        "https://identity.foundation/didcomm-messaging/service-endpoint/v1",
+    ],
+    "serviceEndpoint": [
+        {
+            "id": "did:indy:sovrin:123456#didcomm",
+            "type": "didcomm-messaging",
+            "serviceEndpoint": "https://example.com",
+            "recipientKeys": ["#verkey"],
+            "routingKeys": [],
+        }
+    ],
+}
+diddoc_content_json = json.dumps(diddoc_content)
+
+
+# Prepare nym with role endorser and no diddoc content
+@pytest.fixture(scope="module")
+def prepare_endorser(looper, sdk_pool_handle, sdk_wallet_steward, sdk_wallet_endorser):
+    _, did_steward = sdk_wallet_steward
+    wh, _ = sdk_wallet_endorser
+    seed = randomString(32)
+    dest, verkey = looper.loop.run_until_complete(
+        create_and_store_my_did(wh, json.dumps({"seed": seed}))
+    )
+    nym_request = build_nym_request(did_steward, dest, verkey, None, ENDORSER)
+    request_couple = sdk_sign_and_send_prepared_request(
+        looper, sdk_wallet_steward, sdk_pool_handle, nym_request
+    )
+    sdk_get_and_check_replies(looper, [request_couple])
+
+
+# Add diddoc content to nym
+@pytest.fixture(scope="module")
+def add_diddoc_content(looper, sdk_pool_handle, sdk_wallet_endorser, prepare_endorser):
+    _, did = sdk_wallet_endorser
+    nym_request = build_nym_request(did, did, None, diddoc_content, None)
+    request_couple = sdk_sign_and_send_prepared_request(
+        looper, sdk_wallet_endorser, sdk_pool_handle, nym_request
+    )
+    sdk_get_and_check_replies(looper, [request_couple])
+
+
+def test_get_nym_data_with_diddoc_content_without_seqNo_or_timestamp(
+    looper, sdk_pool_handle, sdk_wallet_endorser, add_diddoc_content
+):
+    _, did = sdk_wallet_endorser
+    get_nym_request = build_get_nym_request(did, did)
+    request_couple = sdk_sign_and_send_prepared_request(
+        looper, sdk_wallet_endorser, sdk_pool_handle, get_nym_request
+    )
+    replies = sdk_get_and_check_replies(looper, [request_couple])
+
+    assert (
+        json.loads(replies[0][1]["result"]["data"])["diddocContent"] == diddoc_content_json
+    )
+
+
+def test_get_previous_nym_data_by_timestamp(
+    looper, sdk_pool_handle, sdk_wallet_endorser, add_diddoc_content
+):
+    _, did = sdk_wallet_endorser
+
+    # Get current nym data
+    get_nym_request = build_get_nym_request(did, did)
+    request_couple = sdk_sign_and_send_prepared_request(
+        looper, sdk_wallet_endorser, sdk_pool_handle, get_nym_request
+    )
+    replies = sdk_get_and_check_replies(looper, [request_couple])
+
+    # Get timestamp from data
+    timestamp = replies[0][1]["result"]["txnTime"]
+
+    # Write new nym data
+    new_diddoc_content = copy.deepcopy(diddoc_content)
+    new_diddoc_content["serviceEndpoint"][0][
+        "serviceEndpoint"
+    ] = "https://new.example.com"
+    new_diddoc_content = json.dumps(new_diddoc_content)
+
+    time.sleep(3)
+
+    nym_request = build_nym_request(
+        identifier=did, dest=did, diddoc_content=new_diddoc_content
+    )
+    request_couple = sdk_sign_and_send_prepared_request(
+        looper, sdk_wallet_endorser, sdk_pool_handle, nym_request
+    )
+    sdk_get_and_check_replies(looper, [request_couple])
+
+    get_nym_request = build_get_nym_request(did, did)
+    request_couple = sdk_sign_and_send_prepared_request(
+        looper, sdk_wallet_endorser, sdk_pool_handle, get_nym_request
+    )
+    replies = sdk_get_and_check_replies(looper, [request_couple])
+
+    assert (
+        json.loads(replies[0][1]["result"]["data"])["diddocContent"] == new_diddoc_content
+    )
+
+    update_ts = replies[0][1]["result"]["txnTime"]
+
+    # Get previous nym data by exact timestamp
+    get_nym_request = build_get_nym_request(did, did, timestamp)
+    request_couple = sdk_sign_and_send_prepared_request(
+        looper, sdk_wallet_endorser, sdk_pool_handle, get_nym_request
+    )
+    replies = sdk_get_and_check_replies(looper, [request_couple])
+
+    assert (
+        json.loads(replies[0][1]["result"]["data"])["diddocContent"] == diddoc_content_json
+    )
+
+    # Get previous nym data by timestamp but not exact
+    ts = randint(timestamp + 1, update_ts - 1)
+    get_nym_request = build_get_nym_request(did, did, ts)
+    request_couple = sdk_sign_and_send_prepared_request(
+        looper, sdk_wallet_endorser, sdk_pool_handle, get_nym_request
+    )
+    replies = sdk_get_and_check_replies(looper, [request_couple])
+
+    assert (
+        json.loads(replies[0][1]["result"]["data"])["diddocContent"] == diddoc_content_json
+    )
+
+
+def test_get_previous_nym_data_by_seq_no(
+    looper, sdk_pool_handle, sdk_wallet_endorser, add_diddoc_content
+):
+    _, did = sdk_wallet_endorser
+
+    # Get current nym data
+    get_nym_request = build_get_nym_request(did, did)
+    request_couple = sdk_sign_and_send_prepared_request(
+        looper, sdk_wallet_endorser, sdk_pool_handle, get_nym_request
+    )
+    replies = sdk_get_and_check_replies(looper, [request_couple])
+
+    # Get seq_no from data
+    seq_no = replies[0][1]["result"]["seqNo"]
+
+    # Write new nym data
+    new_diddoc_content = copy.deepcopy(diddoc_content)
+    new_diddoc_content["serviceEndpoint"][0][
+        "serviceEndpoint"
+    ] = "https://new.example.com"
+    new_diddoc_content = json.dumps(new_diddoc_content)
+
+    time.sleep(3)
+
+    nym_request = build_nym_request(did, did, None, new_diddoc_content, None)
+    request_couple = sdk_sign_and_send_prepared_request(
+        looper, sdk_wallet_endorser, sdk_pool_handle, nym_request
+    )
+    sdk_get_and_check_replies(looper, [request_couple])
+
+    get_nym_request = build_get_nym_request(did, did)
+    request_couple = sdk_sign_and_send_prepared_request(
+        looper, sdk_wallet_endorser, sdk_pool_handle, get_nym_request
+    )
+    replies = sdk_get_and_check_replies(looper, [request_couple])
+
+    assert (
+        json.loads(replies[0][1]["result"]["data"])["diddocContent"] == new_diddoc_content
+    )
+
+    # Get previous nym data by seq_no
+    get_nym_request = build_get_nym_request(did, did, seq_no=seq_no)
+    request_couple = sdk_sign_and_send_prepared_request(
+        looper, sdk_wallet_endorser, sdk_pool_handle, get_nym_request
+    )
+    replies = sdk_get_and_check_replies(looper, [request_couple])
+
+    assert (
+        json.loads(replies[0][1]["result"]["data"])["diddocContent"] == diddoc_content_json
+    )
+
+
+def test_nym_txn_rejected_with_both_seqNo_and_timestamp(
+    looper, sdk_pool_handle, sdk_wallet_endorser, add_diddoc_content
+):
+    _, did = sdk_wallet_endorser
+
+    # Get current nym data
+    get_nym_request = build_get_nym_request(did, did)
+    request_couple = sdk_sign_and_send_prepared_request(
+        looper, sdk_wallet_endorser, sdk_pool_handle, get_nym_request
+    )
+    replies = sdk_get_and_check_replies(looper, [request_couple])
+
+    # Get timestamp from data
+    timestamp = replies[0][1]["result"]["txnTime"]
+    seq_no = replies[0][1]["result"]["seqNo"]
+
+    # Write new nym data
+    new_diddoc_content = copy.deepcopy(diddoc_content)
+    new_diddoc_content["serviceEndpoint"][0][
+        "serviceEndpoint"
+    ] = "https://new.example.com"
+    new_diddoc_content = json.dumps(new_diddoc_content)
+
+    time.sleep(3)
+
+    nym_request = build_nym_request(
+        identifier=did, dest=did, diddoc_content=new_diddoc_content
+    )
+    request_couple = sdk_sign_and_send_prepared_request(
+        looper, sdk_wallet_endorser, sdk_pool_handle, nym_request
+    )
+    sdk_get_and_check_replies(looper, [request_couple])
+
+    get_nym_request = build_get_nym_request(did, did)
+    request_couple = sdk_sign_and_send_prepared_request(
+        looper, sdk_wallet_endorser, sdk_pool_handle, get_nym_request
+    )
+    replies = sdk_get_and_check_replies(looper, [request_couple])
+
+    assert (
+        json.loads(replies[0][1]["result"]["data"])["diddocContent"] == new_diddoc_content
+    )
+
+    # Get previous nym data by exact timestamp
+    get_nym_request = build_get_nym_request(did, did, timestamp, seq_no)
+
+    with pytest.raises(InvalidClientRequest):
+        sdk_sign_and_send_prepared_request(
+        looper, sdk_wallet_endorser, sdk_pool_handle, get_nym_request
+    )

--- a/indy_node/test/request_handlers/test_get_nym_handler.py
+++ b/indy_node/test/request_handlers/test_get_nym_handler.py
@@ -6,10 +6,13 @@ from random import randint
 import pytest
 from indy.did import create_and_store_my_did
 from indy_common.constants import ENDORSER
+from indy_node.test.helper import sdk_send_and_check_req_json
 from indy_node.test.mock import build_get_nym_request, build_nym_request
+from plenum.common.exceptions import RequestNackedException
 from plenum.common.util import randomString
 from plenum.test.helper import sdk_get_and_check_replies
 from plenum.test.pool_transactions.helper import sdk_sign_and_send_prepared_request
+
 
 diddoc_content = {
     "@context": [
@@ -189,3 +192,59 @@ def test_get_previous_nym_data_by_seq_no(
     assert (
         json.loads(replies[0][1]["result"]["data"])["diddocContent"] == diddoc_content_json
     )
+
+
+def test_nym_txn_rejected_with_both_seqNo_and_timestamp(
+    looper, sdk_pool_handle, sdk_wallet_endorser, add_diddoc_content
+):
+
+    _, did = sdk_wallet_endorser
+
+    # Get current nym data
+    get_nym_request = build_get_nym_request(did, did)
+    request_couple = sdk_sign_and_send_prepared_request(
+        looper, sdk_wallet_endorser, sdk_pool_handle, get_nym_request
+    )
+    replies = sdk_get_and_check_replies(looper, [request_couple])
+
+    # Get timestamp from data
+    timestamp = replies[0][1]["result"]["txnTime"]
+    seq_no = replies[0][1]["result"]["seqNo"]
+
+    # Write new nym data
+    new_diddoc_content = copy.deepcopy(diddoc_content)
+    new_diddoc_content["serviceEndpoint"][0][
+        "serviceEndpoint"
+    ] = "https://new.example.com"
+    new_diddoc_content = json.dumps(new_diddoc_content)
+
+    time.sleep(3)
+
+    nym_request = build_nym_request(
+        identifier=did, dest=did, diddoc_content=new_diddoc_content
+    )
+    request_couple = sdk_sign_and_send_prepared_request(
+        looper, sdk_wallet_endorser, sdk_pool_handle, nym_request
+    )
+    sdk_get_and_check_replies(looper, [request_couple])
+
+    get_nym_request = build_get_nym_request(did, did)
+    request_couple = sdk_sign_and_send_prepared_request(
+        looper, sdk_wallet_endorser, sdk_pool_handle, get_nym_request
+    )
+    replies = sdk_get_and_check_replies(looper, [request_couple])
+
+    assert (
+        json.loads(replies[0][1]["result"]["data"])["diddocContent"] == new_diddoc_content
+    )
+
+    # Attempt to get previous nym data by exact timestamp and seqNo
+    get_nym_request = build_get_nym_request(did, did, timestamp, seq_no)
+
+    with pytest.raises(RequestNackedException) as e:
+        sdk_send_and_check_req_json(
+            looper, sdk_pool_handle, sdk_wallet_endorser, get_nym_request
+        )
+    e.match("InvalidClientRequest")
+    e.match("client request invalid")
+    e.match("Cannot resolve nym with both seqNo and timestamp present.")

--- a/indy_node/test/request_handlers/test_get_nym_handler.py
+++ b/indy_node/test/request_handlers/test_get_nym_handler.py
@@ -5,8 +5,7 @@ from random import randint
 
 import pytest
 from indy.did import create_and_store_my_did
-from indy_common.constants import ENDORSER, NYM
-from plenum.common.exceptions import InvalidClientRequest
+from indy_common.constants import ENDORSER
 from indy_node.test.mock import build_get_nym_request, build_nym_request
 from plenum.common.util import randomString
 from plenum.test.helper import sdk_get_and_check_replies
@@ -189,56 +188,4 @@ def test_get_previous_nym_data_by_seq_no(
 
     assert (
         json.loads(replies[0][1]["result"]["data"])["diddocContent"] == diddoc_content_json
-    )
-
-
-def test_nym_txn_rejected_with_both_seqNo_and_timestamp(
-    looper, sdk_pool_handle, sdk_wallet_endorser, add_diddoc_content
-):
-    _, did = sdk_wallet_endorser
-
-    # Get current nym data
-    get_nym_request = build_get_nym_request(did, did)
-    request_couple = sdk_sign_and_send_prepared_request(
-        looper, sdk_wallet_endorser, sdk_pool_handle, get_nym_request
-    )
-    replies = sdk_get_and_check_replies(looper, [request_couple])
-
-    # Get timestamp from data
-    timestamp = replies[0][1]["result"]["txnTime"]
-    seq_no = replies[0][1]["result"]["seqNo"]
-
-    # Write new nym data
-    new_diddoc_content = copy.deepcopy(diddoc_content)
-    new_diddoc_content["serviceEndpoint"][0][
-        "serviceEndpoint"
-    ] = "https://new.example.com"
-    new_diddoc_content = json.dumps(new_diddoc_content)
-
-    time.sleep(3)
-
-    nym_request = build_nym_request(
-        identifier=did, dest=did, diddoc_content=new_diddoc_content
-    )
-    request_couple = sdk_sign_and_send_prepared_request(
-        looper, sdk_wallet_endorser, sdk_pool_handle, nym_request
-    )
-    sdk_get_and_check_replies(looper, [request_couple])
-
-    get_nym_request = build_get_nym_request(did, did)
-    request_couple = sdk_sign_and_send_prepared_request(
-        looper, sdk_wallet_endorser, sdk_pool_handle, get_nym_request
-    )
-    replies = sdk_get_and_check_replies(looper, [request_couple])
-
-    assert (
-        json.loads(replies[0][1]["result"]["data"])["diddocContent"] == new_diddoc_content
-    )
-
-    # Get previous nym data by exact timestamp
-    get_nym_request = build_get_nym_request(did, did, timestamp, seq_no)
-
-    with pytest.raises(InvalidClientRequest):
-        sdk_sign_and_send_prepared_request(
-        looper, sdk_wallet_endorser, sdk_pool_handle, get_nym_request
     )


### PR DESCRIPTION
This PR moves existing tests for the `get_nym_handler` into `test_get_nym_handler.py`, solves the bug in which `test_get_previous_nym_data_by_seq_no` retrieves the updated nym data from `test_get_previous_nym_data_by_seq_no` by converting `sdk_wallet_endorser` into a factory fixture, and adds a test checking that a nym transaction is rejected and raises `InvalidClientRequest` when both `seqNo` and `timestamp` are provided.