### PR TITLE
refactor: use separate method to find timestamp

### DIFF
--- a/indy_node/server/request_handlers/read_req_handlers/get_nym_handler.py
+++ b/indy_node/server/request_handlers/read_req_handlers/get_nym_handler.py
@@ -1,5 +1,3 @@
-from indy_common.constants import GET_NYM, TIMESTAMP, VALUE
-
 from common.serializers.serialization import domain_state_serializer
 from indy_common.constants import GET_NYM, TIMESTAMP
 from indy_node.server.request_handlers.domain_req_handlers.nym_handler import NymHandler
@@ -10,9 +8,7 @@ from plenum.common.types import f
 from plenum.common.txn_util import get_txn_time
 from plenum.common.exceptions import InvalidClientRequest
 from plenum.server.database_manager import DatabaseManager
-from plenum.server.request_handlers.handler_interfaces.read_request_handler import (
-    ReadRequestHandler,
-)
+from plenum.server.request_handlers.handler_interfaces.read_request_handler import ReadRequestHandler
 
 
 class GetNymHandler(ReadRequestHandler):
@@ -21,34 +17,37 @@ class GetNymHandler(ReadRequestHandler):
         self.node = node
 
     def get_result(self, request: Request):
-        # Needs validation that timestamp and seqNo are not set together
         self._validate_request_type(request)
         nym = request.operation[TARGET_NYM]
-        timestamp = request.operation.get(TIMESTAMP, None)
         path = NymHandler.make_state_path_for_nym(nym)
-        # Get old state based on seqNo (versionId) or timestamp.
-        # See https://hyperledger.github.io/indy-did-method/#did-versions
-        timestamp = request.operation.get(TIMESTAMP, None)
-        read_seq_no = request.operation.get("seqNo", None)
-        if timestamp and read_seq_no:
-            raise InvalidClientRequest(
-                request.identifier,
-                request.reqId,
-                "Cannot resolve nym with both seqNo and timestamp present.",
-            )
-        if read_seq_no:
-            # Move to this to init?
-            db = self.database_manager.get_database(DOMAIN_LEDGER_ID)
-            txn = self.node.getReplyFromLedger(db.ledger, read_seq_no, write=False)
-            if txn and "result" in txn:
-                timestamp = get_txn_time(txn.result)
-            if not timestamp:
-                data = None
-                seq_no = None
-                update_time = None
-                proof = None
+        timestamp = self._retrieve_timestamp(request)
+
+        data = None
+        seq_no = None
+        update_time = None
+        proof = None
+
         if timestamp:
-            nym_state_value = self._get_nym_by_timestamp(timestamp, path)
+            nym_data = None
+            past_root = self.database_manager.ts_store.get_equal_or_prev(timestamp)
+            if past_root:
+                encoded_nym, proof = self._get_value_from_state(
+                    path, head_hash=past_root, with_proof=True
+                )
+                if encoded_nym:
+                    nym_data = domain_state_serializer.deserialize(encoded_nym)
+                    seq_no = nym_data[TXN_METADATA_SEQ_NO]
+                    update_time = nym_data[TXN_TIME]
+                    del nym_data[TXN_METADATA_SEQ_NO]
+                    del nym_data[TXN_TIME]
+                    del nym_data["identifier"]
+            nym_state_value = StateValue(
+                root_hash=past_root,
+                value=nym_data,
+                seq_no=seq_no,
+                update_time=update_time,
+                proof=proof,
+            )
             if nym_state_value and nym_state_value.value:
                 nym_data = nym_state_value.value
                 nym_data[TARGET_NYM] = nym
@@ -56,14 +55,7 @@ class GetNymHandler(ReadRequestHandler):
                 seq_no = nym_state_value.seq_no
                 update_time = nym_state_value.update_time
                 proof = nym_state_value.proof
-            # Can't find state for timestamp
-            else:
-                data = None
-                seq_no = None,
-                update_time = None
-                proof = None
-        elif not read_seq_no:
-            # Get current state
+        else:
             nym_data, proof = self._get_value_from_state(path, with_proof=True)
             if nym_data:
                 nym_data = domain_state_serializer.deserialize(nym_data)
@@ -71,10 +63,6 @@ class GetNymHandler(ReadRequestHandler):
                 data = domain_state_serializer.serialize(nym_data)
                 seq_no = nym_data[f.SEQ_NO.nm]
                 update_time = nym_data[TXN_TIME]
-            else:
-                data = None
-                seq_no = None
-                update_time = None
 
         result = self.make_result(
             request=request,
@@ -87,27 +75,18 @@ class GetNymHandler(ReadRequestHandler):
         result.update(request.operation)
         return result
 
-    def _get_nym_by_timestamp(self, timestamp, path_to_nym):
-        nym_data = None
-        seq_no = None
-        last_update_time = None
-        nym_data_proof = None
-        past_root = self.database_manager.ts_store.get_equal_or_prev(timestamp)
-        if past_root:
-            encoded_nym, nym_data_proof = self._get_value_from_state(
-                path_to_nym, head_hash=past_root, with_proof=True
+    def _retrieve_timestamp(self, request: Request):
+        timestamp = request.operation.get(TIMESTAMP, None)
+        read_seq_no = request.operation.get("seqNo", None)
+        if timestamp and read_seq_no:
+            raise InvalidClientRequest(
+                request.identifier,
+                request.reqId,
+                "Cannot resolve nym with both seqNo and timestamp present.",
             )
-            if encoded_nym:
-                nym_data = domain_state_serializer.deserialize(encoded_nym)
-                seq_no = nym_data[TXN_METADATA_SEQ_NO]
-                last_update_time = nym_data[TXN_TIME]
-                del nym_data[TXN_METADATA_SEQ_NO]
-                del nym_data[TXN_TIME]
-                del nym_data["identifier"]
-        return StateValue(
-            root_hash=past_root,
-            value=nym_data,
-            seq_no=seq_no,
-            update_time=last_update_time,
-            proof=nym_data_proof,
-        )
+        elif read_seq_no:
+            db = self.database_manager.get_database(DOMAIN_LEDGER_ID)
+            txn = self.node.getReplyFromLedger(db.ledger, read_seq_no, write=False)
+            if txn and "result" in txn:
+                timestamp = get_txn_time(txn.result)
+        return timestamp


### PR DESCRIPTION
This PR refactors the `GetNymHandler`. This control flow uses one `if/else` statement to retrieve the nym with or without a timestamp. Whether the timestamp is retrieved directly or via the corresponding sequence number is determined in a separate method `_retrieve_timestamp`. This method either returns a timestamp, returns `None` (the current state will be retrieved without using a timestamp), or raises `InvalidClientRequest` if both the timestamp and sequence number are retrieved.

Signed-off-by: Char Howland <char@indicio.tech>