### PR TITLE
Feature/self cert

### DIFF
--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -9,6 +9,7 @@ on:
     branches:
       - ubuntu-20.04-upgrade
       - feature/did-indy*
+      - feature/self-cert
   workflow_dispatch: 
 
 jobs:

--- a/indy_node/server/request_handlers/domain_req_handlers/nym_handler.py
+++ b/indy_node/server/request_handlers/domain_req_handlers/nym_handler.py
@@ -209,6 +209,14 @@ class NymHandler(PNymHandler):
 
         updateKeys = [ROLE, VERKEY]
         updateKeysInOperationOrOwner = is_owner
+
+        if NYM_VERSION in operation:
+            raise InvalidClientRequest(
+                request.identifier,
+                request.reqId,
+                "Cannot set version on existing nym"
+            )
+
         for key in updateKeys:
             if key in operation:
                 updateKeysInOperationOrOwner = True
@@ -227,9 +235,6 @@ class NymHandler(PNymHandler):
                     ],
                 )
         if not updateKeysInOperationOrOwner:
-            raise InvalidClientRequest(request.identifier, request.reqId)
-
-        if nym_data.get(NYM_VERSION):
             raise InvalidClientRequest(request.identifier, request.reqId)
 
     def _decode_state_value(self, encoded):

--- a/indy_node/server/request_handlers/domain_req_handlers/nym_handler.py
+++ b/indy_node/server/request_handlers/domain_req_handlers/nym_handler.py
@@ -178,7 +178,7 @@ class NymHandler(PNymHandler):
                     "Non-ledger nym txn must contain verkey for new did",
                 )
 
-        version = nym_data.get(NYM_VERSION)
+        version = request.operation.get(NYM_VERSION)
         if version == 1 and not self._legacy_convention_validation(
             request.operation.get(TARGET_NYM), request.operation.get(VERKEY)
         ):

--- a/indy_node/server/request_handlers/domain_req_handlers/nym_handler.py
+++ b/indy_node/server/request_handlers/domain_req_handlers/nym_handler.py
@@ -257,7 +257,7 @@ class NymHandler(PNymHandler):
     def _legacy_convention_validation(self, did, verkey):
         """did:sov method validation: the did is derived
         from the first 16 bytes of the verkey"""
-        return did == base58.b58decode(verkey).digest()[:16]
+        return did == base58.b58encode(base58.b58decode(verkey)[:16])
 
     def _validate_diddoc_content(self, diddoc):
 

--- a/indy_node/server/request_handlers/domain_req_handlers/nym_handler.py
+++ b/indy_node/server/request_handlers/domain_req_handlers/nym_handler.py
@@ -229,6 +229,9 @@ class NymHandler(PNymHandler):
         if not updateKeysInOperationOrOwner:
             raise InvalidClientRequest(request.identifier, request.reqId)
 
+        if nym_data.get(NYM_VERSION):
+            raise InvalidClientRequest(request.identifier, request.reqId)
+
     def _decode_state_value(self, encoded):
         if encoded:
             return domain_state_serializer.deserialize(encoded)

--- a/indy_node/server/request_handlers/domain_req_handlers/nym_handler.py
+++ b/indy_node/server/request_handlers/domain_req_handlers/nym_handler.py
@@ -22,7 +22,7 @@ from indy_common.constants import (
 # TODO - Improve exception with reason
 from indy_common.exceptions import InvalidDIDDocException
 from ledger.util import F
-from plenum.common.constants import ROLE, TARGET_NYM, TXN_TIME, VERKEY, NYM_VERSION
+from plenum.common.constants import ROLE, TARGET_NYM, TXN_TIME, VERKEY
 from plenum.common.exceptions import InvalidClientRequest
 from plenum.common.request import Request
 from plenum.common.txn_util import (

--- a/indy_node/server/request_handlers/domain_req_handlers/nym_handler.py
+++ b/indy_node/server/request_handlers/domain_req_handlers/nym_handler.py
@@ -156,10 +156,6 @@ class NymHandler(PNymHandler):
         nym_data = self.database_manager.idr_cache.getNym(
             request.identifier, isCommitted=False
         )
-
-        nym_data = self.database_manager.idr_cache.getNym(
-            request.identifier, isCommitted=False
-        )
         if not nym_data:
             # Non-ledger nym case. These two checks duplicated and mainly executed in client_authn,
             # but it has point to repeat them here, for clear understanding of validation non-ledger request cases.

--- a/indy_node/server/request_handlers/read_req_handlers/get_nym_handler.py
+++ b/indy_node/server/request_handlers/read_req_handlers/get_nym_handler.py
@@ -3,7 +3,7 @@ from indy_common.constants import GET_NYM, TIMESTAMP
 from common.serializers.serialization import domain_state_serializer
 from indy_node.server.request_handlers.domain_req_handlers.nym_handler import NymHandler
 from indy_node.server.request_handlers.utils import StateValue
-from plenum.common.constants import TARGET_NYM, TXN_TIME, DOMAIN_LEDGER_ID, TXN_METADATA_SEQ_NO
+from plenum.common.constants import TARGET_NYM, TXN_TIME, DOMAIN_LEDGER_ID, TXN_METADATA_SEQ_NO, NYM_VERSION
 from plenum.common.request import Request
 from plenum.common.types import f
 from plenum.common.txn_util import get_txn_time
@@ -52,6 +52,7 @@ class GetNymHandler(ReadRequestHandler):
             if nym_state_value and nym_state_value.value:
                 nym_data = nym_state_value.value
                 nym_data[TARGET_NYM] = nym
+                nym_data[NYM_VERSION] = nym_data.get(NYM_VERSION, 0)
                 data = domain_state_serializer.serialize(nym_data)
                 seq_no = nym_state_value.seq_no
                 update_time = nym_state_value.update_time
@@ -61,6 +62,7 @@ class GetNymHandler(ReadRequestHandler):
             if nym_data:
                 nym_data = domain_state_serializer.deserialize(nym_data)
                 nym_data[TARGET_NYM] = nym
+                nym_data[NYM_VERSION] = nym_data.get(NYM_VERSION, 0)
                 data = domain_state_serializer.serialize(nym_data)
                 seq_no = nym_data[f.SEQ_NO.nm]
                 update_time = nym_data[TXN_TIME]

--- a/indy_node/server/request_handlers/read_req_handlers/get_nym_handler.py
+++ b/indy_node/server/request_handlers/read_req_handlers/get_nym_handler.py
@@ -1,9 +1,9 @@
-from indy_common.constants import GET_NYM, TIMESTAMP
+from indy_common.constants import GET_NYM, TIMESTAMP, NYM_VERSION
 
 from common.serializers.serialization import domain_state_serializer
 from indy_node.server.request_handlers.domain_req_handlers.nym_handler import NymHandler
 from indy_node.server.request_handlers.utils import StateValue
-from plenum.common.constants import TARGET_NYM, TXN_TIME, DOMAIN_LEDGER_ID, TXN_METADATA_SEQ_NO, NYM_VERSION
+from plenum.common.constants import TARGET_NYM, TXN_TIME, DOMAIN_LEDGER_ID, TXN_METADATA_SEQ_NO
 from plenum.common.request import Request
 from plenum.common.types import f
 from plenum.common.txn_util import get_txn_time

--- a/indy_node/test/request_handlers/test_get_nym_handler.py
+++ b/indy_node/test/request_handlers/test_get_nym_handler.py
@@ -250,3 +250,18 @@ def test_nym_txn_rejected_with_both_seqNo_and_timestamp(
     e.match("InvalidClientRequest")
     e.match("client request invalid")
     e.match("Cannot resolve nym with both seqNo and timestamp present.")
+
+
+def test_get_nym_handler_returns_default_nym_version(
+    looper, sdk_pool_handle, sdk_wallet_endorser, add_diddoc_content
+):
+    _, did = sdk_wallet_endorser
+    get_nym_request = build_get_nym_request(did, did)
+    request_couple = sdk_sign_and_send_prepared_request(
+        looper, sdk_wallet_endorser, sdk_pool_handle, get_nym_request
+    )
+    replies = sdk_get_and_check_replies(looper, [request_couple])
+
+    assert (
+        json.loads(replies[0][1]["result"]["data"])["version"] == 0
+    )

--- a/indy_node/test/request_handlers/test_nym_handler.py
+++ b/indy_node/test/request_handlers/test_nym_handler.py
@@ -247,3 +247,17 @@ def test_nym_validation_self_certifying(nym_request: Request, nym_handler: NymHa
     with pytest.raises(InvalidClientRequest) as e:
         nym_handler._validate_new_nym(nym_request, nym_request.operation)
     e.match("Nym with version 1 must be first 16 bytes of verkey")
+
+
+def test_nym_validation_legacy_convetion(nym_request: Request, nym_handler: NymHandler, doc, nym_request_factory):
+    nym_request = nym_request_factory(doc)
+    nym_request.operation[NYM_VERSION] = 2
+    nym_request.operation[TARGET_NYM] = "X3XUxYQM2cfkSMzfMNma73"
+    nym_request.operation[VERKEY] = "HNjfjoeZ7WAHYDSzWcvzyvUABepctabD7QSxopM48fYz"
+    txn = reqToTxn(nym_request)
+    seq_no = 1
+    txn_time = 1560241033
+    append_txn_metadata(txn, seq_no, txn_time)
+    with pytest.raises(InvalidClientRequest) as e:
+        nym_handler._validate_new_nym(nym_request, nym_request.operation)
+    e.match("DID is not self-certifying; must be first 16 bytes of SHA256 of verkey")

--- a/indy_node/test/request_handlers/test_nym_handler.py
+++ b/indy_node/test/request_handlers/test_nym_handler.py
@@ -233,3 +233,17 @@ def test_fail_on_version_update(nym_request: Request, nym_handler: NymHandler, d
     with pytest.raises(InvalidClientRequest) as e:
         nym_handler._validate_existing_nym(nym_request, nym_request.operation, nym_data)
     e.match("Cannot set version on existing nym")
+
+
+def test_nym_validation_self_certifying(nym_request: Request, nym_handler: NymHandler, doc, nym_request_factory):
+    nym_request = nym_request_factory(doc)
+    nym_request.operation[NYM_VERSION] = 1
+    nym_request.operation[TARGET_NYM] = "X3XUxYQM2cfkSMzfMNma73"
+    nym_request.operation[VERKEY] = "HNjfjoeZ7WAHYDSzWcvzyvUABepctabD7QSxopM48fYz"
+    txn = reqToTxn(nym_request)
+    seq_no = 1
+    txn_time = 1560241033
+    append_txn_metadata(txn, seq_no, txn_time)
+    with pytest.raises(InvalidClientRequest) as e:
+        nym_handler._validate_new_nym(nym_request, nym_request.operation)
+    e.match("Nym with version 1 must be first 16 bytes of verkey")

--- a/indy_node/test/request_handlers/test_nym_handler.py
+++ b/indy_node/test/request_handlers/test_nym_handler.py
@@ -173,15 +173,6 @@ def test_nym_dynamic_validation_for_new_nym(
         nym_handler.dynamic_validation(nym_request, 0)
 
 
-def test_nym_dynamic_validation_for_new_nym_fails_not_self_certifying(
-    nym_request, nym_handler: NymHandler
-):
-    with enable_did_indy(nym_handler):
-        nym_request.operation["dest"] = "V4SGRU86Z58d6TV7PBUe6f"
-        with pytest.raises(InvalidClientRequest):
-            nym_handler.additional_dynamic_validation(nym_request, None)
-
-
 def test_nym_dynamic_validation_for_existing_nym(
     nym_request: Request, nym_handler: NymHandler, creator
 ):


### PR DESCRIPTION
This PR allows the `GetNymHandler` to return nym `version`, ensures that nym transactions on existing nyms cannot update the `version`, and validates the nym according to its `version`.