### PR TITLE
Docs/clarification updates

### DIFF
--- a/indy_common/test/types/test_nym.py
+++ b/indy_common/test/types/test_nym.py
@@ -12,6 +12,9 @@ def validator():
 
 
 def test_nym(validator):
+    """Validate that the NYM transaction accepts only JSON
+    strings as DIDDOC_CONTENT."""
+
     msg = {
         TXN_TYPE: NYM,
         TARGET_NYM: VALID_TARGET_NYM,
@@ -21,6 +24,8 @@ def test_nym(validator):
 
 
 def test_nym_raw_dictionary(validator):
+    """Validate that the NYM transaction does not accept
+    dictionaries as DIDDOC_CONTENT."""
     msg = {
         TXN_TYPE: NYM,
         TARGET_NYM: VALID_TARGET_NYM,

--- a/indy_node/server/request_handlers/read_req_handlers/get_attribute_handler.py
+++ b/indy_node/server/request_handlers/read_req_handlers/get_attribute_handler.py
@@ -39,6 +39,9 @@ class GetAttributeHandler(VersionReadRequestHandler):
                 f"{VERSION_ID} and {VERSION_TIME} are mutually exclusive; only one should be "
                 "specified",
             )
+        # The above check determines whether the request is valid
+        # A similar check in VersionReadRequestHandler determines
+        # whether the method is used correctly
 
         if not validate_attrib_keys(operation):
             raise InvalidClientRequest(

--- a/indy_node/server/request_handlers/read_req_handlers/get_nym_handler.py
+++ b/indy_node/server/request_handlers/read_req_handlers/get_nym_handler.py
@@ -30,6 +30,9 @@ class GetNymHandler(VersionReadRequestHandler):
                 f"{VERSION_ID} and {VERSION_TIME} are mutually exclusive; only one should be "
                 "specified",
             )
+        # The above check determines whether the request is valid
+        # A similar check in VersionReadRequestHandler determines
+        # whether the method is used correctly
 
         data = None
         last_seq_no = None

--- a/indy_node/server/request_handlers/read_req_handlers/version_read_request_handler.py
+++ b/indy_node/server/request_handlers/read_req_handlers/version_read_request_handler.py
@@ -38,6 +38,9 @@ class VersionReadRequestHandler(ReadRequestHandler):
         """
         if seq_no is not None and timestamp is not None:
             raise ValueError("seq_no and timestamp are mutually exclusive")
+        # The above check determines whether the method is used correctly
+        # A similar check in GetNymHandler and GetAttributeHandler determines
+        # whether the request is valid
 
         if seq_no:
             timestamp = self._timestamp_from_seq_no(seq_no)


### PR DESCRIPTION
This PR adds documentation to:
- Emphasize the difference between the mutual exclusion tests for `seq_no` and `timestamp` in `VersionReadRequestHandler` versus `GetNymHandler`/`GetAttributeHandler`
- Emphasize the difference between `test_nym` (checks that on JSON strings are accepted as `DIDDOC_CONTENT`) and `test_nym_raw_dictionary` (a regression test to check that dictionaries are not accepted as `DIDDOC_CONTENT`)